### PR TITLE
Removed scale argument and added h to saveImage function.

### DIFF
--- a/R/RCy3.R
+++ b/R/RCy3.R
@@ -175,7 +175,7 @@ setGeneric ('getDefaultEdgeReverseSelectionColor',  signature='obj',
 setGeneric ('setDefaultEdgeReverseSelectionColor',  signature='obj',
                 function (obj, new.color, vizmap.style.name='default') standardGeneric ('setDefaultEdgeReverseSelectionColor'))
 
-setGeneric ('saveImage',                  signature='obj', function (obj, file.name, image.type, scale=1.0) standardGeneric ('saveImage'))
+setGeneric ('saveImage',                  signature='obj', function (obj, file.name, image.type, h=600) standardGeneric ('saveImage'))
 setGeneric ('saveNetwork',                signature='obj', function (obj, file.name, format='cys') standardGeneric ('saveNetwork'))
 
 setGeneric ('setDefaultNodeShape',        signature='obj', function (obj, new.shape, vizmap.style.name='default') standardGeneric ('setDefaultNodeShape'))
@@ -5151,25 +5151,29 @@ setMethod ('setDefaultEdgeReverseSelectionColor',  'CytoscapeConnectionClass',
       })
 #------------------------------------------------------------------------------------------------------------------------
 setMethod ('saveImage', 'CytoscapeWindowClass',
-
-   function (obj, file.name, image.type, scale=1.0) {
-      image.type = tolower (image.type)
-      stopifnot (image.type %in% c ('png', 'pdf', 'svg'))
-      id = as.character (obj@window.id)
-      
-      if (!file.exists(file.name)){
-        # TODO Comment TanjaM - scaling not possible with the new version -- remove?
-          
-        # get the view image from Cytoscape in PNG, PDF, or SVG format
-        resource.uri <- paste(obj@uri, pluginVersion(obj), "networks", id,
-                              paste0("views/first.", image.type), sep="/")
-
-        request.res <- GET(resource.uri, write_disk(paste0(file.name,".", image.type), overwrite = TRUE))
-        write (sprintf ('saving image to %s.%s', file.name, image.type), stderr ())
-      }else{
-          write (sprintf ('choose another filename. File exists: %s', file.name), stderr ())
-      }
-     }) # saveImage
+           
+           function (obj, file.name, image.type, h = 600) {
+             image.type = tolower (image.type)
+             stopifnot (image.type %in% c ('png', 'pdf', 'svg'))
+             id = as.character (obj@window.id)
+             
+             if (!file.exists(file.name)){
+               if(image.type=='png'){
+                 
+                 resource.uri <- paste(obj@uri, pluginVersion(obj), "networks", id,
+                                       paste0("views/first.", image.type, "?h=", h), sep="/")  
+               } 
+               else{
+                 # get the view image from Cytoscape in PNG, PDF, or SVG format
+                 resource.uri <- paste(obj@uri, pluginVersion(obj), "networks", id,
+                                       paste0("views/first.", image.type), sep="/")
+               }
+               request.res <- GET(resource.uri, write_disk(paste0(file.name,".", image.type), overwrite = TRUE))
+               write (sprintf ('saving image to %s.%s', file.name, image.type), stderr ())
+             }else{
+               write (sprintf ('choose another filename. File exists: %s', file.name), stderr ())
+             }
+           }) # saveImage
 #------------------------------------------------------------------------------------------------------------------------
 setMethod ('saveNetwork', 'CytoscapeWindowClass',
 

--- a/man/saveImage.Rd
+++ b/man/saveImage.Rd
@@ -3,13 +3,14 @@
 \alias{saveImage,CytoscapeWindowClass-method}
 \title{saveImage}
 \description{
-Write an image of the specified type to the specified file, at the
-specified scaling factor.  Note: the file is written to the file system
-of the computer upon which R is running, not Cytoscape -- in those cases
-where they are different. It is saved to the working directory.
+Write an image of the specified type to the specified file. For image type 'png'
+there is an option to set the height of the image (see argument h). Note: the file
+is written to the file system of the computer upon which R is running, not 
+Cytoscape -- in those cases where they are different. It is saved to the working
+directory.
 }
 \usage{
-saveImage(obj, file.name, image.type, scale)
+saveImage(obj, file.name, image.type, h = 600)
 }
 \arguments{
 
@@ -17,7 +18,7 @@ saveImage(obj, file.name, image.type, scale)
   \item{file.name}{a \code{char} object. Use an explicit, full path, or
   this file will be written into your home directory.}
   \item{image.type}{a \code{char} object. 'png', 'pdf', 'svg' are the only image types currently supported}
-  \item{scale}{a \code{numeric} object.  How large (or small) to  scale the image. }
+  \item{h}{a \code{numeric} object. The height of the image. Width will be automatically set based on the height. Option only available for 'png' image type. All other image types use the default of 600 for the height and it is not adjustable.}
 }
 
 \value{
@@ -39,7 +40,8 @@ None.
   layoutNetwork(cw, 'force-directed')
   redraw (cw)
   filename <- paste (getwd (), 'saveImageTest', sep='/')
-  saveImage (cw, filename, 'svg', 2.0)   # currently supports svg, pdf and png
+  saveImage (cw, filename, 'svg')   # currently supports svg, pdf and png
+  saveImage(cw, filename, 'png', 1600)
 }
 
 \keyword{graph}


### PR DESCRIPTION
The scale argument is not an option for resizing images using cyREST so it was removed. For images of type 'png' there is an option to set the height of the image and this argument was added for pngs. Closes #35
